### PR TITLE
LinkCardを削除した時に、更新しないとCardが残り続ける問題を解消

### DIFF
--- a/client/src/components/Card.js
+++ b/client/src/components/Card.js
@@ -54,6 +54,7 @@ class Card extends React.Component {
           return;
         }
         window.alert(res.body.msg);
+        this.props.getLinkData();
       });
   }
 
@@ -81,13 +82,7 @@ class Card extends React.Component {
               <p>{this.state.comment}</p>
             </a>
             {actionBtn}
-            <button
-              style={styles.buttonD}
-              onClick={() => {
-                this.delete();
-                this.props.getLinkData();
-              }}
-            >
+            <button style={styles.buttonD} onClick={() => this.delete()}>
               削除
             </button>
           </li>


### PR DESCRIPTION
#36 

アプローチ方法
- TopPageにてLinkCardをDBから取得し、stateにセットしているメソッドをdeleteメソッド内で呼び出すことで、deleteした時に全LinkCardのデータが更新されてrenderされる事を利用した。